### PR TITLE
Adding speech input via custom element

### DIFF
--- a/src/quartapp/static/speech.js
+++ b/src/quartapp/static/speech.js
@@ -1,0 +1,87 @@
+class SpeechRecordButton extends HTMLElement {
+    constructor() {
+        super();
+        this.attachShadow({ mode: 'open' });
+        this.shadowRoot.innerHTML = `
+            <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha3/dist/css/bootstrap.min.css"
+                integrity="sha384-KK94CHFLLe+nY2dmCWGMq91rCGa5gtU4mk92HdvYe+M/SXH301p5ILy+dN9+nJOZ" crossorigin="anonymous">
+            <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.3/font/bootstrap-icons.css"
+                integrity="sha256-4RctOgogjPAdwGbwq+rxfwAmSpZhWaafcZR9btzUk18=" crossorigin="anonymous">
+            <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootswatch@5.2.3/dist/cosmo/bootstrap.min.css"
+                integrity="sha256-axRDISYf7Hht1KhcMnfDV2nq7hD/8Q9Rxa0YlW/o3NU=" crossorigin="anonymous">
+            <button class="btn btn-secondary" type="button" id="record-button">
+                <i class="bi bi-mic"></i>
+            </button>
+        `;
+        this.isRecording = false;
+        this.speechRecognition = this.useCustomSpeechRecognition();
+        this.recordButton = this.shadowRoot.getElementById('record-button');
+        this.recordButton.addEventListener('click', () => this.toggleRecording());
+    }
+
+    useCustomSpeechRecognition() {
+        const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
+        if (!SpeechRecognition) {
+            console.error("SpeechRecognition not supported");
+            return null;
+        }
+        const speechRecognition = new SpeechRecognition();
+        speechRecognition.lang = navigator.language || navigator.userLanguage;
+        console.log(`Using language: ${speechRecognition.lang}`);
+        speechRecognition.interimResults = false;
+        speechRecognition.maxAlternatives = 1;
+        return speechRecognition;
+    }
+
+    startRecording() {
+        console.log("Starting speech recognition");
+        if (this.speechRecognition == null) {
+            console.error("SpeechRecognition not supported");
+            return;
+        }
+
+        this.speechRecognition.onresult = (event) => {
+            let input = "";
+            for (const result of event.results) {
+                input += result[0].transcript;
+            }
+            console.log(`Speech recognition result: ${input}`);
+            this.dispatchEvent(new CustomEvent('speechresult', { detail: { transcript: input } }));
+        };
+
+        this.speechRecognition.onend = () => {
+            console.log("Speech recognition ended");
+            // NOTE: In some browsers (e.g. Chrome), the recording will stop automatically after a few seconds of silence.
+            this.isRecording = false;
+            this.recordButton.innerHTML = '<i class="bi bi-mic"></i>';
+            this.dispatchEvent(new Event('speechend'));
+        };
+
+        this.speechRecognition.onerror = (event) => {
+            if (this.speechRecognition) {
+                this.speechRecognition.stop();
+                if (event.error == "no-speech") {
+                    this.dispatchEvent(new CustomEvent('speecherror', { detail: { error: "No speech was detected. Please check your system audio settings and try again." } }));
+                } else if (event.error == "language-not-supported") {
+                    this.dispatchEvent(new CustomEvent('speecherror', { detail: { error: "The selected language is not supported. Please try a different language." } }));
+                } else {
+                    this.dispatchEvent(new CustomEvent('speecherror', { detail: { error: "An error occurred while recording. Please try again." } }));
+                }
+            }
+        };
+
+        this.speechRecognition.start();
+        this.isRecording = true;
+        this.recordButton.innerHTML = '<i class="bi bi-mic-fill"></i>';
+    }
+
+    toggleRecording() {
+        if (this.isRecording) {
+            this.speechRecognition.stop();
+        } else {
+            this.startRecording();
+        }
+    }
+}
+
+customElements.define('speech-record-button', SpeechRecordButton);

--- a/src/quartapp/templates/index.html
+++ b/src/quartapp/templates/index.html
@@ -62,9 +62,10 @@
                             <input id="file" name="file" class="form-control form-control-sm" type="file" accept=".png, .jpg" aria-label="Upload File"></input>
                         </div>
 
+
                         <label for="message" class="form-label bi" style="color:white">Ask question about image:</label>
                         <div class="input-group">
-                            <i class="bi bi-body-text input-group-text" aria-hidden="true"></i>
+                            <speech-record-button></speech-record-button>
                             <input id="message" name="message" class="form-control form-control-sm" type="text" rows="1" placeholder="<Your Message>" aria-label="Ask ChatGPT"></input>
                             <button type="submit" class="btn btn-outline-light">
                                 Send
@@ -79,7 +80,7 @@
     </main>
     <script src="https://cdn.jsdelivr.net/npm/showdown@2.1.0/dist/showdown.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/@microsoft/ai-chat-protocol@1.0.0-beta.20240610.1/dist/iife/index.js"></script>
-
+    <script src="/static/speech.js"></script>
     <script>
         const form = document.getElementById("chat-form");
         const messageInput = document.getElementById("message");
@@ -110,6 +111,14 @@
             } else {
                 imagePreview.style.display = "none";
             }
+        });
+
+        const speechRecordButton = document.querySelector('speech-record-button');
+        speechRecordButton.addEventListener('speechresult', (event) => {
+            messageInput.value += " " + event.detail.transcript.trim()
+        });
+        speechRecordButton.addEventListener('speecherror', (event) => {
+            alert(event.detail.error);
         });
 
         form.addEventListener("submit", async function(e) {


### PR DESCRIPTION
## Purpose

This pull request adds a new custom HTML element for speech recognition and integrates it into the existing web application. The most important changes include the creation of the `SpeechRecordButton` class, its incorporation into the chat form, and the addition of necessary event listeners.

### New Feature: Speech Recognition

* **`src/quartapp/static/speech.js`**: Introduced a new custom HTML element `SpeechRecordButton` that handles speech recognition using the Web Speech API. This class includes methods for starting and stopping recording, and dispatches custom events based on speech recognition results or errors.

### Integration into Chat Form

* **`src/quartapp/templates/index.html`**: Added the `speech-record-button` custom element next to the message input field in the chat form.
* **`src/quartapp/templates/index.html`**: Included the `speech.js` script to ensure the `SpeechRecordButton` class is available.
* **`src/quartapp/templates/index.html`**: Added event listeners for `speechresult` and `speecherror` events to update the message input field and handle errors respectively.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Press button, say something, see it show up in the text box.