### PR TITLE
Scope azd deployment job to a GitHub Environment

### DIFF
--- a/.github/workflows/azure-dev.yaml
+++ b/.github/workflows/azure-dev.yaml
@@ -19,6 +19,7 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    environment: production
     outputs:
       uri: ${{ steps.output.outputs.uri }}
     env:


### PR DESCRIPTION
Binds the azd deployment job in `azure-dev.yaml` to a GitHub `production` Environment.

Scoping the deploy job to an Environment lets deployment configuration be managed through environment protection rules (required reviewers, branch/tag restrictions, wait timers) and keeps deployment-time configuration grouped per environment. This aligns with the recommended `azd` CI/CD pipeline setup.

No workflow logic changes - only adds `environment: production` to the `build` job.

> Note: a `production` environment may need to be created in repo settings (Settings -> Environments) for the job to run; reviewers can confirm during review.